### PR TITLE
Task 3795 add action to download dist directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
           git config --global user.name "github-actions[bot]"
-          git add dist
+          git add -f dist
           git commit -m "Update dist directory"
 
       - name: Push changes


### PR DESCRIPTION
Changes proposed in this pull request:
- Try deploying dist on push to master


Unblocks outfunnel/webapp#
https://github.com/outfunnel/webapp/issues/3795
